### PR TITLE
refactor(scripts): Proper method names instead of `runPkg`

### DIFF
--- a/about.js
+++ b/about.js
@@ -121,6 +121,7 @@ async function _allDependencies (pkg, path = '', known = {}) {
 }
 const allDependencies = cached([__filename], _allDependencies)
 
+
 async function depInfo (pkg) {
   const usedIn = packagesIn('.')
     .filter(name => name !== pkg && existsSync(path.join('.', name, NODE_MODULES, pkg)))
@@ -144,7 +145,7 @@ async function depInfo (pkg) {
   return {deps, outdated, size, usedIn}
 }
 
-async function runPkg (pkg) {
+async function updateAbout (pkg) {
   const dependencies = await depInfo(pkg)
   console.log(JSON.stringify(dependencies, null, 2))
   writeJsonSync(
@@ -157,7 +158,7 @@ async function runPkg (pkg) {
 async function run (...args) {
   await forEach(allDependencies, TOOLS)
   await flushAll()
-  return forEach(runPkg, args)
+  return forEach(updateAbout, args)
 }
 
 module.exports = {

--- a/cache.js
+++ b/cache.js
@@ -56,7 +56,7 @@ function cached (keys, resolve) {
   if (!existsSync(CACHE_DIR)) mkdirSync(CACHE_DIR)
   const hash = asFileName(...keys, hashFunction(resolve)) + '.json'
   const file = path.join(CACHE_DIR, hash)
-  return async (...args) => {
+  const fun = async (...args) => {
     let cache = await getCache(file)
 
     const cacheKey = args
@@ -78,6 +78,8 @@ function cached (keys, resolve) {
     flushLater(file)
     return value
   }
+  fun.name = `cached(${hashFunction(resolve)})`
+  return fun;
 }
 
 module.exports = {cached, flushAll}

--- a/dump.js
+++ b/dump.js
@@ -4,7 +4,7 @@ const path = require('path')
 const {forEach} = require('./iterate')
 const {execJson} = require('./execJSON')
 
-function runPkg (pkg) {
+function collectDumps (pkg) {
   writeJsonSync(
     path.join(pkg, 'dump.report.json'),
     dumps.reduce(
@@ -36,7 +36,7 @@ function runPkg (pkg) {
 }
 
 async function run (...args) {
-  return forEach(runPkg, args)
+  return forEach(collectDumps, args)
 }
 
 module.exports = {

--- a/install.js
+++ b/install.js
@@ -1,12 +1,12 @@
 const {forEach} = require('./iterate')
 const {execSync} = require('child_process')
 
-function runPkg (pkg) {
+function npmInstall (pkg) {
   execSync('npm install', {stdio: 'inherit', cwd: pkg})
 }
 
 async function run (...args) {
-  await forEach(runPkg, args)
+  await forEach(npmInstall, args)
   if (!process.env.CI) {
     execSync('runex about', {stdio: 'inherit'})
   }


### PR DESCRIPTION
When all scripts have a `runPkg` to iterate over the packages,
in the output it is often not clear what is happening,
especially when multiple scripts are run in one go